### PR TITLE
ROI support

### DIFF
--- a/omero_fpbioimage/templates/fpbioimage/viewer.html
+++ b/omero_fpbioimage/templates/fpbioimage/viewer.html
@@ -7,7 +7,7 @@
 
   <!-- EDIT THIS JAVASCRIPT! -->
   <script type='text/javascript'>
-    pathToImages = "{% url 'fpbioimage_index' %}imageStacks/{{ image.id }}"; // This is the path relative to the FPBioimage parent folder
+    pathToImages = "{% url 'fpbioimage_index' %}imageStacks/{{ image.id }}{% if region %}/{{ region }}{% endif %}"; // This is the path relative to the FPBioimage parent folder
     uniqueName = "fpbioimage_{{ image.id }}"; // Give this image stack a unique name for bookmarking to work correctly
     numberOfImages = {{ image.getSizeZ }};  // Number of images in the stack
     imagePrefix = "";  // The prefix of the image stack file names
@@ -67,9 +67,13 @@
   <!-- Full screen button -->
   <div class="w3-container w3-center" style="padding:0px">
     <table><tr>
-      <td style="vertical-align:middle; text-align:left"><h4>Images generated in OMERO. </h4></td>
+      <td style="vertical-align:middle; text-align:left">
+        <h4>Images generated in OMERO. </h4>
+        <button id="load_rois">Load Rectangle ROIs</button>
+      </td>
       <td style="vertical-align:middle; text-align:right"><img src="{% static 'fpbioimage/resources/fullscreen.png' %}" height="40px" alt="Fullscreen" title="Fullscreen" onclick="SetFullscreen(1);" /></td>
     </tr></table>
+    <table id="rois_table" style="width: 600px;"></table>
   </div>
 
 <!-- Footer -->
@@ -80,6 +84,37 @@
   </p>
   <img src="{% static 'fpbioimage/resources/LAGlogo.png' %}" width="65%" alt="Laser Analytics Group"><img src="{% static 'fpbioimage/resources/cambridgeLogo.png' %}" width="25%" alt="University of Cambridge">
 </footer>
+
+<script>
+
+  document.getElementById('load_rois').addEventListener('click', function(){
+    var xhr = new XMLHttpRequest();
+    var rois_url = "{% url 'api_image_rois' 0 image.id %}";
+    xhr.open('GET', rois_url, true);
+    xhr.onload = function() {
+      var responseText = xhr.responseText;
+      var jsonResponse = JSON.parse(responseText);
+      // go through ROIs, filtering shapes for Rectangle
+      var rois_with_rects = jsonResponse.data.filter(function(roi){
+        var rects = roi.shapes.filter(function(shape) {
+          return shape['@type'].endsWith('Rectangle');
+        });
+        return rects.length > 0;
+      });
+      // Show first Rectangle for each ROI
+      var base_url = document.location.href.split('?')[0];
+      var html = rois_with_rects.map(function(roi){
+        var r = roi.shapes[0];
+        var query = 'x=' + parseInt(r.X) + '&y=' + parseInt(r.Y) + '&width=' + parseInt(r.Width) + '&height=' + parseInt(r.Height);
+        var h = '<tr><td>ROI: ' + roi['@id'] + '</td><td>Shape: ' + r['@id'] + '</td>';
+        h += '<td>Load Region: <a href="' + base_url + '?' + query + '"/>x:' + r.X + ' y:' + r.Y + ' width:' + r.Width + ' height:' + r.Height + '</a></td></tr>';
+        return h;
+      });
+      document.getElementById('rois_table').innerHTML = html.join("");
+    }
+    xhr.send();
+  });
+</script>
 </div>
 
 </body>

--- a/omero_fpbioimage/urls.py
+++ b/omero_fpbioimage/urls.py
@@ -38,7 +38,10 @@ urlpatterns = patterns(
     url(r'^viewer/(?P<image_id>[0-9]+)/', views.fpbioimage,
         name='fpbioimage_viewer'),
 
-    # PNG plane. This is used for 'first_image'
-    url(r'^imageStacks/(?P<image_id>[0-9]+)/(?:x:(?P<x>[0-9]+)y:(?P<y>[0-9]+)w:(?P<w>[0-9]+)h:(?P<h>[0-9]+)/)?(?P<the_z>[0-9]+)\.png',
+    # PNG plane. This is used for 'first_image'.
+    # Can include /x:10y:20w:100h:200/ to specify region
+    url(r'^imageStacks/(?P<image_id>[0-9]+)/'
+        '(?:x:(?P<x>[0-9]+)y:(?P<y>[0-9]+)w:(?P<w>[0-9]+)h:(?P<h>[0-9]+)/)?'
+        '(?P<the_z>[0-9]+)\.png',
         views.fpbioimage_png, name='fpbioimage_png'),
 )

--- a/omero_fpbioimage/urls.py
+++ b/omero_fpbioimage/urls.py
@@ -39,13 +39,6 @@ urlpatterns = patterns(
         name='fpbioimage_viewer'),
 
     # PNG plane. This is used for 'first_image'
-    url(r'^imageStacks/(?P<image_id>[0-9]+)/(?P<the_z>[0-9]+)\.png',
+    url(r'^imageStacks/(?P<image_id>[0-9]+)/(?:x:(?P<x>[0-9]+)y:(?P<y>[0-9]+)w:(?P<w>[0-9]+)h:(?P<h>[0-9]+)/)?(?P<the_z>[0-9]+)\.png',
         views.fpbioimage_png, name='fpbioimage_png'),
-
-    # PNG planes to load whole stack.
-    # Can't seem to control how this url is generated in JavaScript from
-    # the 'first_image' url above. So it's ugly but this works for now.
-    url(r'^viewer//fpbioimage/imageStacks/'
-        '(?P<image_id>[0-9]+)/(?P<the_z>[0-9]+)\.png',
-        views.fpbioimage_png, name='fpbioimage_png2'),
 )

--- a/omero_fpbioimage/views.py
+++ b/omero_fpbioimage/views.py
@@ -70,7 +70,7 @@ def fpbioimage(request, image_id, conn=None, **kwargs):
     w = request.GET.get('width')
     h = request.GET.get('height')
     if x is not None and y is not None and \
-        w is not None and h is not None:
+            w is not None and h is not None:
         context['region'] = 'x:%sy:%sw:%sh:%s' % (x, y, w, h)
 
     return render(request, 'fpbioimage/viewer.html', context)


### PR DESCRIPTION
When an image is loaded in the viewer, you can load any Rectangular ROIs saved
on the image....

<img width="653" alt="screen shot 2017-05-27 at 21 16 43" src="https://cloud.githubusercontent.com/assets/900055/26524189/16553362-4323-11e7-839d-2ef3c94aabc8.png">

Clicking on a region in the list will re-load the page with url like
```fpbioimage/viewer/3455/?x=228&y=333&width=107&height=108```

This will load the specified region in the viewer instead of the whole image.
Specifying the region in this way could also be used to directly view a region of the image,
(e.g. url generated via open_with).