### PR TITLE
fix padded slice width division

### DIFF
--- a/omero_fpbioimage/views.py
+++ b/omero_fpbioimage/views.py
@@ -100,8 +100,8 @@ def fpbioimage_png(request, image_id, atlas_index, conn=None, **kwargs):
     max_size = 512
     if slice_width > max_size or slice_height > max_size:
         longest_side = max(slice_width, slice_height)
-        slice_width = (slice_width * max_size) / longest_side
-        slice_height = (slice_height * max_size) / longest_side
+        slice_width = (slice_width * max_size) // longest_side
+        slice_height = (slice_height * max_size) // longest_side
 
     num_slices = image.getSizeZ()
 


### PR DESCRIPTION
Fixes viewing larger images (> 512 x 512) in FPBioImage.

Test:
 - https://py3-ci.openmicroscopy.org/web/fpbioimage/viewer/3865/ (user-3)

<details><summary>Stack trace</summary>

```
          Traceback (most recent call last):

  File "/home/omero/workspace/OMERO-web/omero-virtualenv/lib/python3.6/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)

  File "/home/omero/workspace/OMERO-web/omero-virtualenv/lib/python3.6/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)

  File "/home/omero/workspace/OMERO-web/omero-virtualenv/lib/python3.6/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)

  File "/home/omero/workspace/OMERO-web/OMERO.web/lib/python/omeroweb/decorators.py", line 485, in wrapped
    retval = f(request, *args, **kwargs)

  File "/home/omero/workspace/OMERO-web/omero-virtualenv/lib/python3.6/site-packages/omero_fpbioimage/views.py", line 114, in fpbioimage_png
    padded_slice_width = ceil2(slice_width)

  File "/home/omero/workspace/OMERO-web/omero-virtualenv/lib/python3.6/site-packages/omero_fpbioimage/views.py", line 90, in ceil2
    return 1 << (x - 1).bit_length()

AttributeError: 'float' object has no attribute 'bit_length'

<WSGIRequest: GET '/web/fpbioimage/imageStacks/3865/000.png'>
        
```
</details>
